### PR TITLE
added new cli cluster sut config demo

### DIFF
--- a/demos/mirantis/cli_cluster_sut_config/.gitignore
+++ b/demos/mirantis/cli_cluster_sut_config/.gitignore
@@ -1,0 +1,3 @@
+terraform/.terraform
+terraform/*.state
+terraform/*.tfvars.json

--- a/demos/mirantis/cli_cluster_sut_config/README.md
+++ b/demos/mirantis/cli_cluster_sut_config/README.md
@@ -1,0 +1,53 @@
+# Cluster / SUT Overriding Configuration
+
+A demo on how to use the overriding/overloading features of the config handler
+to get adaptability in your test harness.
+
+This approach preaches some patterns but attempts to be readable enough that
+it can be interpreted for different approaches.
+
+That module actually has a very similar system to this override approach referred
+to as the ltc variation.  There is another demo of the ltc approach which shows
+how you can use the same ideas here but with suts/clusters defined by mirantis
+that relate to our releases and our test cluster definitions.
+
+## Configuration overrides
+
+### Cluster definition
+
+Different cluster definition folders contain config overrides that change the
+cluster definition.
+
+1. poc : man:1, worker:3
+2. small_business: man:3, worker: 20
+3. data_center : man:5, worker:100
+
+(these are not official values, I just picked something that made some sense)
+
+POC is default. There is a pytest option added to select a cluster:
+
+```
+pytest --cluster small_business
+```
+
+### System Under Test
+
+Different Mirantis cloud versions can be installed
+
+1. 202101 : the patch released in 2021 Jan
+1. 202012 : the patch released in 2020 Dec
+
+202101 is Default.  There is a pytest options to select a different sut:
+
+(this is demo data, and may not represent actual values)
+
+```
+pytest --sut 202012
+```
+
+## The terraform plan
+
+This demo uses the PRODENG terraform plan in the mtt_mirantis module.
+
+We use that plan/graph only so that we don't have to include redundant terraform
+here, allowing us to focus on using config overrides functionally.

--- a/demos/mirantis/cli_cluster_sut_config/config/cluster/data_center/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/cluster/data_center/terraform.yml
@@ -1,0 +1,5 @@
+vars:
+    manager_count: 5
+    worker_count: 100
+    msr_count: 10
+    windows_worker_count: 0

--- a/demos/mirantis/cli_cluster_sut_config/config/cluster/poc/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/cluster/poc/terraform.yml
@@ -1,0 +1,5 @@
+vars:
+    manager_count: 1
+    worker_count: 3
+    msr_count: 0
+    windows_worker_count: 0

--- a/demos/mirantis/cli_cluster_sut_config/config/cluster/small_business/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/cluster/small_business/terraform.yml
@@ -1,0 +1,5 @@
+vars:
+    manager_count: 3
+    worker_count: 20
+    msr_count: 3
+    windows_worker_count: 0

--- a/demos/mirantis/cli_cluster_sut_config/config/config.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/config.yml
@@ -1,0 +1,1 @@
+destroy-on-finish: false

--- a/demos/mirantis/cli_cluster_sut_config/config/global.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/global.yml
@@ -1,0 +1,4 @@
+id: "oc"
+project: "TAR"
+
+kube_orchestration: true

--- a/demos/mirantis/cli_cluster_sut_config/config/provisioner.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/provisioner.yml
@@ -1,0 +1,1 @@
+plugin_id: mtt_terraform

--- a/demos/mirantis/cli_cluster_sut_config/config/sut/202012/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/sut/202012/terraform.yml
@@ -1,0 +1,4 @@
+vars:
+    engine_version: "19.03.12"
+    mke_version: "3.3.3"
+    msr_version: "2.8.3"

--- a/demos/mirantis/cli_cluster_sut_config/config/sut/202101/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/sut/202101/terraform.yml
@@ -1,0 +1,4 @@
+vars:
+    engine_version: "19.03.12"
+    mke_version: "3.3.3"
+    msr_version: "2.8.3"

--- a/demos/mirantis/cli_cluster_sut_config/config/terraform.yml
+++ b/demos/mirantis/cli_cluster_sut_config/config/terraform.yml
@@ -1,0 +1,43 @@
+# not actually used, but shows a way to assemble a large id
+id: "{user:id}-{global:project}-{vars.task_name}-{global:cluster}-{global:sut}"
+# put the cluster name up here and use it in multiple places below
+cluster_name: "oc-cluster"
+
+# we are going to put all runtime files in this project path
+files_path: "{path:project}"
+
+state:
+    # wheter the state file will be written
+    path: "{files_path}/terraform/{cluster_name}.terraform.state"
+
+# Where will the vars be written
+vars_path: "{files_path}/terraform/{cluster_name}.tfvars.json"
+
+plan:
+    # mtt_mirantis has config to give us a path to a plan
+    path: "{mtt_mirantis:terraform.plans.prodeng.aws}"
+options:
+    always_init: false
+vars:
+    # pull this value from earlier in the file
+    cluster_name: "{cluster_name}"
+    admin_password: "abcd1234changeme"
+    windows_administrator_password: "tfaws,,CHANGEME..Example"
+    platform: "rhel_7.8"
+    # This is programmatically entered in conftest.py
+    username: "{user:id?user}"
+    # These two are pulled from global.yml
+    task_name: "{global:id}"
+    project: "{global:project}"
+    expire_duration: "72h"
+    kube_orchestration: true
+    msr_install_flags: ["--ucp-insecure-tls"]
+    platform_repo: "public"
+    # These values get overridden in other config files
+    manager_count: 1
+    worker_count: 3
+    msr_count: 0
+    windows_worker_count: 0
+    engine_version: "19.03.12"
+    mke_version: "3.3.3"
+    msr_version: "2.8.3"

--- a/demos/mirantis/cli_cluster_sut_config/conftest.py
+++ b/demos/mirantis/cli_cluster_sut_config/conftest.py
@@ -1,0 +1,144 @@
+import logging
+import pytest
+import pathlib
+import getpass
+from datetime import datetime
+import os.path
+
+logging.basicConfig(encoding='utf-8', level=logging.INFO)
+logger = logging.getLogger('mtt ltc demo')
+
+DIR = str(pathlib.Path(__file__).parent.absolute())
+""" Absolute path to this file, used as a root path """
+
+# Import the mtt core
+import mirantis.testing.mtt as mtt
+# Import packages that we use
+# 1. this import some functions that we use
+# 2. this activates the module decorators, which registers plugins
+import mirantis.testing.mtt_common as mtt_common
+# we are going to use a terraform plan fro this module
+import mirantis.testing.mtt_mirantis as mtt_mirantis
+# this will give us access to the terraform provisioner
+import mirantis.testing.mtt_terraform as mtt_terraform
+
+# Defaults / keys related to cli options
+
+CONFIG_FOLDER = "config"
+
+CONFIG_CLUSTER_FOLDER = "cluster"
+OPTIONS_CLUSTER_FLAG = "--cluster"
+CLUSTER_DEFAULT = "poc"
+
+CONFIG_SUT_FOLDER = "sut"
+OPTIONS_SUT_FLAG = "--sut"
+SUT_DEFAULT = "202101"
+
+def pytest_addoption(parser):
+    """ Add pytest cli options to allow --sut and --cluster """
+    parser.addoption(OPTIONS_CLUSTER_FLAG, action="store", default=CLUSTER_DEFAULT)
+    parser.addoption(OPTIONS_SUT_FLAG, action="store", default=SUT_DEFAULT)
+
+@pytest.fixture(scope='session')
+def config(request):
+    """
+
+    Create a config object.
+
+    We add sources for:
+    - our own ./config
+    - some dynamic overrides pulled from cli options
+    - whichever --sut / --cluster (or defaults) where chosend
+
+    """
+
+    project_config_path = os.path.join(DIR, CONFIG_FOLDER)
+
+    config = mtt.new_config()
+    # Add our ./config path as a config source
+    config.add_source(mtt_common.MTT_PLUGIN_ID_CONFIGSOURCE_PATH, 'project_config').set_path(project_config_path)
+
+    # Add cluster configuration from cli option
+    project_config_clusterpath = os.path.join(project_config_path, CONFIG_CLUSTER_FOLDER)
+    cluster = request.session.config.getoption(OPTIONS_CLUSTER_FLAG)
+    if not os.path.isdir(os.path.join(project_config_clusterpath, cluster)):
+        logger.warning("'%s' cluster has no available configuration. PyTest will default to '%s'", cluster, CLUSTER_DEFAULT)
+        cluster = CLUSTER_DEFAULT
+    config.add_source(mtt_common.MTT_PLUGIN_ID_CONFIGSOURCE_PATH, 'cluster', priority=80).set_path(os.path.join(project_config_clusterpath, cluster))
+
+    # Add sut configuration from cli option
+    project_config_sutpath = os.path.join(project_config_path, CONFIG_SUT_FOLDER)
+    sut = request.session.config.getoption(OPTIONS_SUT_FLAG)
+    if not os.path.isdir(os.path.join(project_config_sutpath, sut)):
+        logger.warning("'%s' sut has no available configuration. PyTest will default to '%s'", sut, SUT_DEFAULT)
+        sut = SUT_DEFAULT
+    config.add_source(mtt_common.MTT_PLUGIN_ID_CONFIGSOURCE_PATH, 'sut', priority=80).set_path(os.path.join(project_config_sutpath, sut))
+
+    # Add some dymanic values for config
+    config.add_source(mtt_common.MTT_PLUGIN_ID_CONFIGSOURCE_DICT, 'dynamic').set_data({
+        "user": {
+            "id": getpass.getuser() # override user id with a host value
+        },
+        "global": {
+            "datetime": datetime.now(), # use a single datetime across all checks
+        },
+        "global": {
+            "datetime": datetime.now(), # use a single datetime across all checks
+            "sut": sut,
+            "cluster": cluster
+        },
+        config.paths_label(): { # special config label for file paths, usually just 'paths'
+            "project": DIR  # you can use 'paths:project' in config to substitute this path
+        }
+    })
+
+    # this can do a lot of things, but we are only using it to access the
+    # terraform plan in this module
+    mtt_mirantis.config_interpret_mtt_mirantis(config)
+
+    return config
+
+@pytest.fixture(scope="session")
+def provisioner(config):
+    """ get a provisioner based on the config """
+    return mtt.new_provisioner_from_config(config)
+
+@pytest.fixture(scope='session')
+def provisioner_up(config, provisioner):
+    """ get the provisioner but start the provisioner before returning
+
+    This is preferable to the raw provisioner in cases where you want a running
+    cluster so that the cluster startup cost does not get reflected in the
+    first test case which uses the fixture.  Also it can tear itself down
+
+    You can still use provisioner.apply() update the resources if the provisioner
+    can handle it.
+    """
+    logger.info("Running MTT provisioner up()")
+
+    conf = config.load("config")
+
+    try:
+        logger.info("Preparing the testing cluster using the provisioner")
+        provisioner.prepare()
+    except Exception as e:
+        logger.error("Provisioner failed to init: %s", e)
+        raise e
+    try:
+        logger.info("Starting up the testing cluster using the provisioner")
+        provisioner.apply()
+    except Exception as e:
+        logger.error("Provisioner failed to start: %s", e)
+        raise e
+
+    yield provisioner
+
+    if conf.get("destroy-on-finish", exception_if_missing=False):
+        try:
+            logger.info("Stopping the test cluster using the provisioner as directed by config")
+            provisioner.destroy()
+        except Exception as e:
+            logger.error("Provisioner failed to stop: %s", e)
+            raise e
+    else:
+        logger.info("Leaving test infrastructure in place on shutdown")

--- a/demos/mirantis/cli_cluster_sut_config/test_sane.py
+++ b/demos/mirantis/cli_cluster_sut_config/test_sane.py
@@ -1,0 +1,16 @@
+
+def test_options(config):
+    """ Can we get a config """
+
+    global_config = config.load("global")
+    print("CLUSTER:{}".format(global_config.get("cluster")))
+    print("SUT:{}".format(global_config.get("sut")))
+
+    terraform_config = config.load("terraform")
+    print("TF_VARS:{}".format(terraform_config.get("vars")))
+
+def test_provisioner(provisioner_up):
+    """ Can we get a running provisioner """
+
+    print("CLUSTER_NAME:{}".format(provisioner_up.output("cluster_name")))
+    print("MKE_CLUSTER_YAML: \n{}".format(provisioner_up.output("mke_cluster_yaml")))


### PR DESCRIPTION
New demo for configuring py test cli to use different configs, with the examples being sut and cluster.  This is based on some common approaches that PRODENG takes on configuring test harnesses.

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>